### PR TITLE
Lauching web pinit url if Pinterest app is not installed.

### DIFF
--- a/Example/PinterestSDK/PDKAppDelegate.m
+++ b/Example/PinterestSDK/PDKAppDelegate.m
@@ -50,7 +50,7 @@ static NSString * const kPDKExampleFakeAppId = @"4759388231231868449";
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
-- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
+- (BOOL)application:(UIApplication *)application openURL:(nonnull NSURL *)url options:(nonnull NSDictionary<NSString *,id> *)options
 {
     return [[PDKClient sharedInstance] handleCallbackURL:url];
 }

--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -29,6 +29,7 @@ static PDKUnauthPinCreationSuccess _pinSuccessBlock = NULL;
 static PDKUnauthPinCreationFailure _pinFailureBlock = NULL;
 
 static NSString * const kPDKPinterestAppPinItURLString = @"pinterestsdk.v1://pinit/";
+static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.com/pin/create/button/";
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
@@ -111,6 +112,11 @@ static NSString * const kPDKPinterestAppPinItURLString = @"pinterestsdk.v1://pin
         [[UIApplication sharedApplication] openURL:pinitURL];
     } else {
         //open web pinit url
+        NSDictionary *webParams = @{@"url": [sourceURL absoluteString],
+                                    @"media": [imageURL absoluteString],
+                                    @"description": pinDescription};
+        NSURL *pinitWebURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestWebPinItURLString, [webParams _PDK_queryStringValue]]];
+        [[UIApplication sharedApplication] openURL:pinitWebURL];
     }
 #else
 #endif


### PR DESCRIPTION
I'm filling out the `else` condition in `[PDKPin pinWithImageURL]` since there's no failure condition if the Pinterest app is not installed on a user's device. I'm not entirely positive this is the right web url but it seems to achieve the same effect as the native integration. 

I also fixed the example app so that it overrides `openURL` which makes the pinit button work properly.