### PR TITLE
Changed AFNetworking dependency version to latest one possible

### DIFF
--- a/PinterestSDK.podspec
+++ b/PinterestSDK.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes'
 
   s.public_header_files = 'Pod/Classes/**/*.h'
-  s.dependency 'AFNetworking', '~> 3.0.3'
+  s.dependency 'AFNetworking', '~> 2.6.3'
   s.dependency 'SSKeychain'
 end

--- a/PinterestSDK.podspec
+++ b/PinterestSDK.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes'
 
   s.public_header_files = 'Pod/Classes/**/*.h'
-  s.dependency 'AFNetworking', '~> 2.3'
+  s.dependency 'AFNetworking', '~> 3.0.3'
   s.dependency 'SSKeychain'
 end


### PR DESCRIPTION
Anyway, since NSURLConnection-based APIs are deprecated, seems like it would be good to move to AFNetoworking 3.X but this looks like needs rewriting of PDKClient-related stuff. 