### PR TITLE
Pass the SDK appId as the app_id to the Pinterest client app

### DIFF
--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -97,7 +97,7 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
     
     NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     
-    NSDictionary *params = @{@"client_id" : [PDKClient sharedInstance].appId,
+    NSDictionary *params = @{@"app_id" : [PDKClient sharedInstance].appId,
                              @"image_url" : [imageURL absoluteString],
                              @"source_url" : [sourceURL absoluteString],
                              @"app_name" : appName,


### PR DESCRIPTION
This has been a long struggle.

* Originally we passed the SDK id as the client_id. This worked, but should not have and at some point stopped working. The client_id is for clients using the old pin-it SDK
* when this stopped working we got errors that we sent an invalid client_id. To fix this we stopped sending a client_id as the backend would cope with this
* if we didn't pass the SDK id to the Pinterest app, the Pinterest app had no way to redirect back to the SDK app. To fix this we put a temporary fix on the backend to allow the appId to come in but be ignored and started sending it as client_id again.
* now the Pinterest app has been updated to look for an 'app_id' to perform a redirect. So we send the SDK id as an app_id to the Pinterst app. A client_id of nil is sent to the pin-it method, and we use app_id for redirects.