### PR TITLE
Add the URL to the pin itself to the PDKPin object

### DIFF
--- a/Pod/Classes/PDKPin.h
+++ b/Pod/Classes/PDKPin.h
@@ -37,6 +37,11 @@ typedef void (^PDKUnauthPinCreationFailure)(NSError *error);
 @property (nonatomic, copy, readonly) NSURL *url;
 
 /**
+ *  The URL to the pin itself
+ */
+@property (nonatomic, copy, readonly) NSURL *pinURL;
+
+/**
  *  The description of the pin
  */
 @property (nonatomic, copy, readonly) NSString *descriptionText;

--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -36,6 +36,7 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
     self = [super initWithDictionary:dictionary];
     if (self) {
         _url = [NSURL URLWithString:dictionary[@"link"]];
+        _pinURL = [NSURL URLWithString:dictionary[@"url"]];
         _descriptionText = dictionary[@"note"];
         _board = [PDKBoard boardFromDictionary:dictionary[@"board"]];
         _creator = [PDKUser userFromDictionary:dictionary[@"creator"]];


### PR DESCRIPTION
Expose the Pin URL in the PDKPin object. I didn't change URL to link as to not break the existing API. However this page "https://developers.pinterest.com/docs/api/pins/" describes URL as "The URL of the Pin on Pinterest." and link as "The URL of the webpage where the Pin was created.". As a compromise I created pinURL instead.