### PR TITLE
Make strings safe when using in NSDictionary;

### DIFF
--- a/Pod/Classes/PDKClient.m
+++ b/Pod/Classes/PDKClient.m
@@ -11,7 +11,6 @@
 #import "PDKPin.h"
 #import "PDKResponseObject.h"
 #import "PDKUser.h"
-
 #import "PDKUtils.h"
 
 #import <SSKeychain/SSKeychain.h>
@@ -84,8 +83,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
           andFailure:(PDKClientFailure)failureBlock
 {
     [[[self class] sharedInstance] getPath:@"oauth/inspect"
-                                parameters:@{@"access_token":PDKSaveString(oauthToken),
-                                             @"token":PDKSaveString(oauthToken)}
+                                parameters:@{@"access_token": PDKSafeString(oauthToken),
+                                             @"token": PDKSafeString(oauthToken)}
                                withSuccess:successBlock
                                 andFailure:failureBlock];
     
@@ -206,9 +205,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
             appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         }
         
-        NSDictionary *params = @{@"client_id" : PDKSaveString(self.appId),
-                                 @"permissions" : PDKSaveString(permissionsString),
-                                 @"app_name" : PDKSaveString(appName)
+        NSDictionary *params = @{@"client_id" : PDKSafeString(self.appId),
+                                 @"permissions" : PDKSafeString(permissionsString),
+                                 @"app_name" : PDKSafeString(appName)
                                  };
         
         // check to see if the Pinterest app is installed
@@ -219,9 +218,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
             [[UIApplication sharedApplication] openURL:oauthURL];
         } else {
             NSString *redirectURL = [NSString stringWithFormat:@"pdk%@://", self.appId];
-            params = @{@"client_id" : PDKSaveString(self.appId),
-                       @"scope" : PDKSaveString(permissionsString),
-                       @"redirect_uri" : PDKSaveString(redirectURL),
+            params = @{@"client_id" : PDKSafeString(self.appId),
+                       @"scope" : PDKSafeString(permissionsString),
+                       @"redirect_uri" : PDKSafeString(redirectURL),
                        @"response_type": @"token",
                        };
             
@@ -406,7 +405,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSMutableDictionary *signedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     
     if (self.oauthToken && signedParameters[@"access_token"] == nil) {
-        signedParameters[@"access_token"] = PDKSaveString(self.oauthToken);
+        signedParameters[@"access_token"] = PDKSafeString(self.oauthToken);
     }
     
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method
@@ -429,7 +428,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSAssert(self.oauthToken, @"self.oauthToken cannot be nil");
     
     NSMutableDictionary *signedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
-    signedParameters[@"access_token"] = PDKSaveString(self.oauthToken);
+    signedParameters[@"access_token"] = PDKSafeString(self.oauthToken);
     
     NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:method
                                                                                 URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString]
@@ -556,8 +555,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
         description = @"";
     }
     NSDictionary *parameters = @{
-                                 @"name" : PDKSaveString(boardName),
-                                 @"description" : PDKSaveString(description)
+                                 @"name" : PDKSafeString(boardName),
+                                 @"description" : PDKSafeString(description)
                                  };
     
     [self postPath:path parameters:parameters withSuccess:successBlock andFailure:failureBlock];
@@ -588,9 +587,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     
     NSDictionary *parameters = @{
                                  @"image_url" : imageURL ? imageURL : @"",
-                                 @"link" : PDKSaveString(link.absoluteString),
-                                 @"board" : PDKSaveString(boardId),
-                                 @"note" : PDKSaveString(pinDescription)
+                                 @"link" : PDKSafeString(link.absoluteString),
+                                 @"board" : PDKSafeString(boardId),
+                                 @"note" : PDKSafeString(pinDescription)
                                  };
     
     [self createPinWithParameters:parameters withSuccess:successBlock andFailure:failureBlock];
@@ -642,8 +641,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     };
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    parameters[@"board"] = PDKSaveString(boardId);
-    parameters[@"note"] = PDKSaveString(pinDescription);
+    parameters[@"board"] = PDKSafeString(boardId);
+    parameters[@"note"] = PDKSafeString(pinDescription);
     if (link != nil) {
         parameters[@"link"] = link;
     }

--- a/Pod/Classes/PDKClient.m
+++ b/Pod/Classes/PDKClient.m
@@ -12,6 +12,8 @@
 #import "PDKResponseObject.h"
 #import "PDKUser.h"
 
+#import "PDKUtils.h"
+
 #import <SSKeychain/SSKeychain.h>
 
 NSString * const PDKClientReadPublicPermissions = @"read_public";
@@ -82,8 +84,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
           andFailure:(PDKClientFailure)failureBlock
 {
     [[[self class] sharedInstance] getPath:@"oauth/inspect"
-                                parameters:@{@"access_token":oauthToken,
-                                             @"token":oauthToken}
+                                parameters:@{@"access_token":PDKSaveString(oauthToken),
+                                             @"token":PDKSaveString(oauthToken)}
                                withSuccess:successBlock
                                 andFailure:failureBlock];
     
@@ -204,9 +206,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
             appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         }
         
-        NSDictionary *params = @{@"client_id" : self.appId,
-                                 @"permissions" : permissionsString,
-                                 @"app_name" : appName
+        NSDictionary *params = @{@"client_id" : PDKSaveString(self.appId),
+                                 @"permissions" : PDKSaveString(permissionsString),
+                                 @"app_name" : PDKSaveString(appName)
                                  };
         
         // check to see if the Pinterest app is installed
@@ -217,9 +219,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
             [[UIApplication sharedApplication] openURL:oauthURL];
         } else {
             NSString *redirectURL = [NSString stringWithFormat:@"pdk%@://", self.appId];
-            params = @{@"client_id" : self.appId,
-                       @"scope" : permissionsString,
-                       @"redirect_uri" : redirectURL,
+            params = @{@"client_id" : PDKSaveString(self.appId),
+                       @"scope" : PDKSaveString(permissionsString),
+                       @"redirect_uri" : PDKSaveString(redirectURL),
                        @"response_type": @"token",
                        };
             
@@ -229,9 +231,9 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
         }
 #else
         NSString *redirectURL = [NSString stringWithFormat:@"pdk%@://", self.appId];
-        params = @{@"client_id" : self.appId,
-                   @"scope" : permissionsString,
-                   @"redirect_uri" : redirectURL,
+        params = @{@"client_id" : PDKSaveString(self.appId),
+                   @"scope" : PDKSaveString(permissionsString),
+                   @"redirect_uri" : PDKSaveString(redirectURL),
                    @"response_type": @"token",
                    };
         
@@ -404,7 +406,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSMutableDictionary *signedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     
     if (self.oauthToken && signedParameters[@"access_token"] == nil) {
-        signedParameters[@"access_token"] = self.oauthToken;
+        signedParameters[@"access_token"] = PDKSaveString(self.oauthToken);
     }
     
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method
@@ -427,7 +429,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSAssert(self.oauthToken, @"self.oauthToken cannot be nil");
     
     NSMutableDictionary *signedParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
-    signedParameters[@"access_token"] = self.oauthToken;
+    signedParameters[@"access_token"] = PDKSaveString(self.oauthToken);
     
     NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:method
                                                                                 URLString:[[NSURL URLWithString:URLString relativeToURL:self.baseURL] absoluteString]
@@ -554,8 +556,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
         description = @"";
     }
     NSDictionary *parameters = @{
-                                 @"name" : boardName,
-                                 @"description" : description
+                                 @"name" : PDKSaveString(boardName),
+                                 @"description" : PDKSaveString(description)
                                  };
     
     [self postPath:path parameters:parameters withSuccess:successBlock andFailure:failureBlock];
@@ -585,10 +587,10 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSAssert(boardId, @"boardId cannot be nil");
     
     NSDictionary *parameters = @{
-                                 @"image_url" : imageURL,
-                                 @"link" : link.absoluteString,
-                                 @"board" : boardId,
-                                 @"note" : pinDescription
+                                 @"image_url" : imageURL ? imageURL : @"",
+                                 @"link" : PDKSaveString(link.absoluteString),
+                                 @"board" : PDKSaveString(boardId),
+                                 @"note" : PDKSaveString(pinDescription)
                                  };
     
     [self createPinWithParameters:parameters withSuccess:successBlock andFailure:failureBlock];
@@ -640,8 +642,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     };
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    parameters[@"board"] = boardId;
-    parameters[@"note"] = pinDescription;
+    parameters[@"board"] = PDKSaveString(boardId);
+    parameters[@"note"] = PDKSaveString(pinDescription);
     if (link != nil) {
         parameters[@"link"] = link;
     }

--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -7,7 +7,6 @@
 #import "PDKCategories.h"
 #import "PDKImageInfo.h"
 #import "PDKUser.h"
-
 #import "PDKUtils.h"
 
 @interface PDKPin()
@@ -99,12 +98,12 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
     
     NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     
-    NSDictionary *params = @{@"app_id" : PDKSaveString([PDKClient sharedInstance].appId),
-                             @"image_url" : PDKSaveString(imageURL.absoluteString),
-                             @"source_url" : PDKSaveString(sourceURL.absoluteString),
-                             @"app_name" : PDKSaveString(appName),
-                             @"suggested_board_name" : PDKSaveString(suggestedBoardName),
-                             @"description" : PDKSaveString(pinDescription),
+    NSDictionary *params = @{@"app_id" : PDKSafeString([PDKClient sharedInstance].appId),
+                             @"image_url" : PDKSafeString(imageURL.absoluteString),
+                             @"source_url" : PDKSafeString(sourceURL.absoluteString),
+                             @"app_name" : PDKSafeString(appName),
+                             @"suggested_board_name" : PDKSafeString(suggestedBoardName),
+                             @"description" : PDKSafeString(pinDescription),
                              };
     
     // check to see if the Pinterest app is installed
@@ -114,9 +113,9 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
         [[UIApplication sharedApplication] openURL:pinitURL];
     } else {
         //open web pinit url
-        NSDictionary *webParams = @{@"url": PDKSaveString(sourceURL.absoluteString),
-                                    @"media": PDKSaveString(imageURL.absoluteString),
-                                    @"description": PDKSaveString(pinDescription)};
+        NSDictionary *webParams = @{@"url": PDKSafeString(sourceURL.absoluteString),
+                                    @"media": PDKSafeString(imageURL.absoluteString),
+                                    @"description": PDKSafeString(pinDescription)};
         NSURL *pinitWebURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestWebPinItURLString, [webParams _PDK_queryStringValue]]];
         [[UIApplication sharedApplication] openURL:pinitWebURL];
     }

--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -8,6 +8,8 @@
 #import "PDKImageInfo.h"
 #import "PDKUser.h"
 
+#import "PDKUtils.h"
+
 @interface PDKPin()
 @property (nonatomic, copy, readwrite) NSURL *url;
 @property (nonatomic, copy, readwrite) NSString *descriptionText;
@@ -97,12 +99,12 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
     
     NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     
-    NSDictionary *params = @{@"app_id" : [PDKClient sharedInstance].appId,
-                             @"image_url" : [imageURL absoluteString],
-                             @"source_url" : [sourceURL absoluteString],
-                             @"app_name" : appName,
-                             @"suggested_board_name" : suggestedBoardName,
-                             @"description" : pinDescription,
+    NSDictionary *params = @{@"app_id" : PDKSaveString([PDKClient sharedInstance].appId),
+                             @"image_url" : PDKSaveString(imageURL.absoluteString),
+                             @"source_url" : PDKSaveString(sourceURL.absoluteString),
+                             @"app_name" : PDKSaveString(appName),
+                             @"suggested_board_name" : PDKSaveString(suggestedBoardName),
+                             @"description" : PDKSaveString(pinDescription),
                              };
     
     // check to see if the Pinterest app is installed
@@ -112,9 +114,9 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
         [[UIApplication sharedApplication] openURL:pinitURL];
     } else {
         //open web pinit url
-        NSDictionary *webParams = @{@"url": [sourceURL absoluteString],
-                                    @"media": [imageURL absoluteString],
-                                    @"description": pinDescription};
+        NSDictionary *webParams = @{@"url": PDKSaveString(sourceURL.absoluteString),
+                                    @"media": PDKSaveString(imageURL.absoluteString),
+                                    @"description": PDKSaveString(pinDescription)};
         NSURL *pinitWebURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestWebPinItURLString, [webParams _PDK_queryStringValue]]];
         [[UIApplication sharedApplication] openURL:pinitWebURL];
     }

--- a/Pod/Classes/PDKUtils.h
+++ b/Pod/Classes/PDKUtils.h
@@ -8,10 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#define PDKSaveString(astring) [PDKUtils safeString:astring]
+#define PDKSafeString(aString) aString ? aString : @""
 
 @interface PDKUtils : NSObject
-
-+ (NSString *)safeString:(NSString *)aString;
 
 @end

--- a/Pod/Classes/PDKUtils.h
+++ b/Pod/Classes/PDKUtils.h
@@ -1,0 +1,17 @@
+//
+//  PDKUtils.h
+//  Pods
+//
+//  Created by Alexey Hippie on 2/20/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#define PDKSaveString(astring) [PDKUtils safeString:astring]
+
+@interface PDKUtils : NSObject
+
++ (NSString *)safeString:(NSString *)aString;
+
+@end

--- a/Pod/Classes/PDKUtils.m
+++ b/Pod/Classes/PDKUtils.m
@@ -1,0 +1,18 @@
+//
+//  PDKUtils.m
+//  Pods
+//
+//  Created by Alexey Hippie on 2/20/16.
+//
+//
+
+#import "PDKUtils.h"
+
+@implementation PDKUtils
+
++ (NSString *)safeString:(NSString *)aString {
+    if (aString) {return aString;}
+    else {return @"";}
+}
+
+@end

--- a/Pod/Classes/PDKUtils.m
+++ b/Pod/Classes/PDKUtils.m
@@ -10,9 +10,4 @@
 
 @implementation PDKUtils
 
-+ (NSString *)safeString:(NSString *)aString {
-    if (aString) {return aString;}
-    else {return @"";}
-}
-
 @end


### PR DESCRIPTION
I faced a bug when trying to checkToken when there is no internet connection or connection failed. PDK tries to create NSDictionary and fill it with nil values. 
Method 
```
- (void)authenticateWithPermissions:(NSArray *)permissions
                             silent:(BOOL)silent
                        withSuccess:(PDKClientSuccess)successBlock
                         andFailure:(PDKClientFailure)failureBlock
```
caused a crash. 
Description is 
```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]'
***
```

So I just put all NSDictionary set fields method with simple macros SDKSaveString to be sure that it wont crash