### PR TITLE
Fix imagesDictionariesSortedBySize in PDKModelObject

### DIFF
--- a/Pod/Classes/PDKModelObject.m
+++ b/Pod/Classes/PDKModelObject.m
@@ -31,8 +31,8 @@
 
 - (NSArray *)imagesDictionariesSortedBySize
 {
-    NSMutableArray *imageDictionaries = [[self.images allValues] mutableCopy];
-    [imageDictionaries sortedArrayWithOptions:NSSortConcurrent usingComparator:^NSComparisonResult(NSDictionary *dictOne, NSDictionary *dictTwo) {
+    NSArray *imageDictionaries = [self.images allValues];
+    NSArray *sortedArray = [imageDictionaries sortedArrayWithOptions:NSSortConcurrent usingComparator:^NSComparisonResult(NSDictionary *dictOne, NSDictionary *dictTwo) {
         PDKImageInfo *infoOne = [PDKImageInfo imageFromDictionary:dictOne];
         PDKImageInfo *infoTwo = [PDKImageInfo imageFromDictionary:dictTwo];
         CGFloat sizeOne = infoOne.width * infoOne.height;
@@ -46,7 +46,7 @@
         }
     }];
     
-    return imageDictionaries;
+    return sortedArray;
 }
 
 - (PDKImageInfo *)smallestImage


### PR DESCRIPTION
PDKModelObject -imagesDictionariesSortedBySize was creating a mutableCopy of the values of the images dictionary property. However it was invoking sortedArrayWithOptions: which is from NSArray and does not mutate the array. 

Removed the mutableCopy and returned the result of the sorting instead.