### PR TITLE
Add Patch request method to allow editing of boards and pins.

### DIFF
--- a/Pod/Classes/PDKClient.h
+++ b/Pod/Classes/PDKClient.h
@@ -192,6 +192,20 @@ typedef void (^PDKPinUploadProgress)(CGFloat percentComplete);
      withSuccess:(PDKClientSuccess)successBlock
       andFailure:(PDKClientFailure)failureBlock;
 
+/**
+ *  Makes a PATCH API request
+ *
+ *  @param path         The path to the endpoint
+ *  @param parameters   Any parameters that need to be sent to the endpoint
+ *  @param successBlock Called when the API call succeeds
+ *  @param failureBlock Called when the API call fails
+ */
+- (void)patchPath:(NSString *)path
+       parameters:(NSDictionary *)parameters
+      withSuccess:(PDKClientSuccess)successBlock
+       andFailure:(PDKClientFailure)failureBlock;
+
+
 #pragma mark - User Endpoints
 /**
  *  Get a PDKUser object for the currently authorized user

--- a/Pod/Classes/PDKClient.m
+++ b/Pod/Classes/PDKClient.m
@@ -374,6 +374,27 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     [self.operationQueue addOperation:operation];
 }
 
+- (void)patchPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+    withSuccess:(PDKClientSuccess)successBlock
+     andFailure:(PDKClientFailure)failureBlock;
+{
+    NSMutableURLRequest *request = [self requestWithMethod:@"PATCH" path:path parameters:parameters];
+        
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request
+                                                                      success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                                                                          if (successBlock && [responseObject isKindOfClass:[NSDictionary class]]) {
+                                                                              PDKResponseObject *response = [[PDKResponseObject alloc] initWithDictionary:(NSDictionary *)responseObject response:operation.response];
+                                                                              successBlock(response);
+                                                                          }
+                                                                      } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                                                          if (failureBlock) {
+                                                                              failureBlock(error);
+                                                                          }
+                                                                      }];
+    [self.operationQueue addOperation:operation];
+}
+
 - (void)deletePath:(NSString *)path
         parameters:(NSDictionary *)parameters
        withSuccess:(PDKClientSuccess)successBlock


### PR DESCRIPTION
Adds patchPath method to the PDKClient class. By adding this method, the PATCH API may be used to edit board and pins.

Tested locally to rename boards and move pins between boards.

Example usage:

```
   NSDictionary *parameters = @{ @"name" : @"NewBoardName" };
        
   NSString *path = @"boards/username/boardname/";
        
   [[PDKClient sharedInstance] patchPath:path 
        parameters:parameters 
       withSuccess:^(PDKResponseObject *responseObject) {
            
       } andFailure:^(NSError *error) {
            
       }
   ];
```