### PR TITLE
Sets iOS 7.0 as deployment target instead of 7.1.

### DIFF
--- a/PinterestSDK.podspec
+++ b/PinterestSDK.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.author           = { "Ricky Cancro" => "ricky@pinterest.com", "Garrett Moon" => "garrett@pinterest.com" }
   s.source           = { :git => "https://github.com/pinterest/ios-pdk.git", :tag => s.version.to_s }
 
-  s.ios.deployment_target = '7.1'
+  s.ios.deployment_target = '7.0'
   s.requires_arc = true
 
   s.weak_frameworks = 'SafariServices'


### PR DESCRIPTION
This will let more folks use the SDK in production.

@rcancro I'll let you make the git tag and update cocoapods after this gets merged