### PR TITLE
Added rate limiting information to PDKResponseObject.

### DIFF
--- a/Pod/Classes/PDKResponseObject.h
+++ b/Pod/Classes/PDKResponseObject.h
@@ -33,8 +33,8 @@ typedef void (^PDKResponseObjectLoadedFailure)(NSError *error);
 /**
  *  Rate limit information based on the call that was made.
  */
-@property (nonatomic, assign) NSUInteger methodRateLimit;
-@property (nonatomic, assign) NSUInteger methodRateRemaining;
+@property (nonatomic, assign) NSInteger rateLimit;
+@property (nonatomic, assign) NSInteger rateRemaining;
 
 /**
  *  For internal use only;

--- a/Pod/Classes/PDKResponseObject.h
+++ b/Pod/Classes/PDKResponseObject.h
@@ -31,6 +31,12 @@ typedef void (^PDKResponseObjectLoadedFailure)(NSError *error);
 @property (nonatomic, strong) NSDictionary *parsedJSONDictionary;
 
 /**
+ *  Rate limit information based on the call that was made.
+ */
+@property (nonatomic, assign) NSUInteger methodRateLimit;
+@property (nonatomic, assign) NSUInteger methodRateRemaining;
+
+/**
  *  For internal use only;
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary response:(NSHTTPURLResponse *)response path:(NSString *)path parameters:(NSDictionary *)parameters;

--- a/Pod/Classes/PDKResponseObject.m
+++ b/Pod/Classes/PDKResponseObject.m
@@ -32,8 +32,8 @@
         
         NSDictionary *allHeaders = [response allHeaderFields];
         
-        _methodRateLimit = [allHeaders[@"X-Ratelimit-Limit"] intValue];
-        _methodRateRemaining = [allHeaders[@"X-Ratelimit-Remaining"] intValue];
+        _rateLimit = [allHeaders[@"X-Ratelimit-Limit"] integerValue];
+        _rateRemaining = [allHeaders[@"X-Ratelimit-Remaining"] integerValue];
 
         _statusCode = response.statusCode;
         _parsedJSONDictionary = [dictionary _PDK_dictionaryByRemovingNulls];

--- a/Pod/Classes/PDKResponseObject.m
+++ b/Pod/Classes/PDKResponseObject.m
@@ -29,6 +29,12 @@
 {
     self = [super init];
     if (self) {
+        
+        NSDictionary *allHeaders = [response allHeaderFields];
+        
+        _methodRateLimit = [allHeaders[@"X-Ratelimit-Limit"] intValue];
+        _methodRateRemaining = [allHeaders[@"X-Ratelimit-Remaining"] intValue];
+
         _statusCode = response.statusCode;
         _parsedJSONDictionary = [dictionary _PDK_dictionaryByRemovingNulls];
         _cursor = _parsedJSONDictionary[@"page"][@"cursor"];


### PR DESCRIPTION
Adds information about the current rate limits to PDKResponseObject. 

This allows a client application to make a single call to an API method, and then check the rate limits on the response object before continuing with a long running batch operation. If the batch operation will take more calls than are currently available, the client is able to warn the user, and wait for the rates limits to reset.

Without this information, it is impossible to determine if a batch operation may fail with a rate limit error before it is complete.

