### PR TITLE
Add the 'url' field to PDKBoard

### DIFF
--- a/Pod/Classes/PDKBoard.h
+++ b/Pod/Classes/PDKBoard.h
@@ -19,6 +19,11 @@
 @property (nonatomic, copy, readonly) NSString *name;
 
 /**
+ *  The URL of the board
+ */
+@property (nonatomic, copy, readonly) NSURL *url;
+
+/**
  *  Description of the board
  */
 @property (nonatomic, copy, readonly) NSString *descriptionText;

--- a/Pod/Classes/PDKBoard.m
+++ b/Pod/Classes/PDKBoard.m
@@ -10,6 +10,7 @@
 @interface PDKBoard()
 
 @property (nonatomic, copy, readwrite) NSString *name;
+@property (nonatomic, copy, readwrite) NSURL *url;
 @property (nonatomic, copy, readwrite) NSString *descriptionText;
 @property (nonatomic, strong, readwrite) PDKUser *creator;
 
@@ -26,6 +27,7 @@
     self = [super initWithDictionary:dictionary];
     if (self) {
         _name = dictionary[@"name"];
+        _url = [NSURL URLWithString:dictionary[@"url"]];
         _descriptionText = dictionary[@"description"];
         _creator = [PDKUser userFromDictionary:dictionary[@"creator"]];
         


### PR DESCRIPTION
This API field has always existed but the model class was missing the
associated property.

The 'url' field is also returned with newly-created boards by default.

Fixes #90