### PR TITLE
Removing write_private and read_private scopes as per the Pinterest p…

### DIFF
--- a/Example/PinterestSDK/PDKViewController.m
+++ b/Example/PinterestSDK/PDKViewController.m
@@ -98,8 +98,6 @@
     __weak PDKViewController *weakSelf = self;
     [[PDKClient sharedInstance] authenticateWithPermissions:@[PDKClientReadPublicPermissions,
                                                               PDKClientWritePublicPermissions,
-                                                              PDKClientReadPrivatePermissions,
-                                                              PDKClientWritePrivatePermissions,
                                                               PDKClientReadRelationshipsPermissions,
                                                               PDKClientWriteRelationshipsPermissions]
                                                 withSuccess:^(PDKResponseObject *responseObject)

--- a/Pod/Classes/PDKClient.h
+++ b/Pod/Classes/PDKClient.h
@@ -9,8 +9,6 @@
  */
 extern NSString * const PDKClientReadPublicPermissions;
 extern NSString * const PDKClientWritePublicPermissions;
-extern NSString * const PDKClientReadPrivatePermissions;
-extern NSString * const PDKClientWritePrivatePermissions;
 extern NSString * const PDKClientReadRelationshipsPermissions;
 extern NSString * const PDKClientWriteRelationshipsPermissions;
 

--- a/Pod/Classes/PDKClient.m
+++ b/Pod/Classes/PDKClient.m
@@ -15,8 +15,6 @@
 
 NSString * const PDKClientReadPublicPermissions = @"read_public";
 NSString * const PDKClientWritePublicPermissions = @"write_public";
-NSString * const PDKClientReadPrivatePermissions = @"read_private";
-NSString * const PDKClientWritePrivatePermissions = @"write_private";
 NSString * const PDKClientReadRelationshipsPermissions = @"read_relationships";
 NSString * const PDKClientWriteRelationshipsPermissions = @"write_relationships";
 


### PR DESCRIPTION
…olicy.

I ran the example app and verified the authentication page no longer shows the bullets about private scopes, nor does the "View Boards" feed show any private boards like it used to (all other feeds never showed private content).

Tagging @jparise @rcancro @garrettmoon for review.