### PR TITLE
Pass in the ViewController that presents the SafariViewController so the SafariViewController can be displayed and dismissed properly.

### DIFF
--- a/Pod/Classes/PDKClient.h
+++ b/Pod/Classes/PDKClient.h
@@ -100,10 +100,12 @@ typedef void (^PDKPinUploadProgress)(CGFloat percentComplete);
  *  a user's cached token is still valid, try silentlyAuthenticateWithSuccess:andFailure:.
  *
  *  @param permissions  List of permissions to request from the user's Pinterest account
+ *  @param presentingViewController The ViewController the SafariViewController (if available) will present from if the Pinterest app is not installed. If nil, an attempt will be made to automatically determine the proper presenting view controller.
  *  @param successBlock called when the API request succeeds
  *  @param failureBlock called when the API request fails
  */
 - (void)authenticateWithPermissions:(NSArray *)permissions
+                 fromViewController:(UIViewController *)presentingViewController
                         withSuccess:(PDKClientSuccess)successBlock
                          andFailure:(PDKClientFailure)failureBlock;
 
@@ -112,11 +114,13 @@ typedef void (^PDKPinUploadProgress)(CGFloat percentComplete);
  *  property. If there is no cached oauth token this method will call the failure block and do 
  *  nothing else (i.e., no app switching to authenticate). 
  *
+ *  @param presentingViewController The ViewController the SafariViewController (if available) will present from if the Pinterest app is not installed. If nil, an attempt will be made to automatically determine the proper presenting view controller.
  *  @param successBlock called if the cached token can be used to authenticate
  *  @param failureBlock called if there is no cached token
  */
-- (void)silentlyAuthenticateWithSuccess:(PDKClientSuccess)successBlock
-                                 andFailure:(PDKClientFailure)failureBlock;
+- (void)silentlyAuthenticatefromViewController:(UIViewController *)presentingViewController
+                                   WithSuccess:(PDKClientSuccess)successBlock
+                                    andFailure:(PDKClientFailure)failureBlock;
 
 /**
  *  After the user authorizes his/her Pinterest account, control switches back to the
@@ -423,9 +427,9 @@ typedef void (^PDKPinUploadProgress)(CGFloat percentComplete);
                 andFailure:(PDKClientFailure)failureBlock;
 
 /**
- *  Method used to open a URL. In iOS9 if the URL is a web address it uses SFSafariViewController. 
+ *  Method used to open a URL. If the URL is a web address, we try to present a SFSafariViewController from the presentingViewController.
  * In earlier versions it uses UIApplication's openURL
  */
-+ (void)openURL:(NSURL *)url;
++ (void)openURL:(NSURL *)url fromViewController:(UIViewController *)presentingViewController;
 
 @end

--- a/Pod/Classes/PDKClient.m
+++ b/Pod/Classes/PDKClient.m
@@ -37,6 +37,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
 @property (nonatomic, assign, readwrite) BOOL authorized;
 @property (nonatomic, copy) PDKClientSuccess authenticationSuccessBlock;
 @property (nonatomic, copy) PDKClientFailure authenticationFailureBlock;
+@property (nonatomic) UIViewController *safariViewController;
 
 @end
 
@@ -136,19 +137,21 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
 
 // authentication
 
-- (void)silentlyAuthenticateWithSuccess:(PDKClientSuccess)successBlock
-                             andFailure:(PDKClientFailure)failureBlock
+- (void)silentlyAuthenticatefromViewController:(UIViewController *)presentingViewController
+                                   WithSuccess:(PDKClientSuccess)successBlock
+                                    andFailure:(PDKClientFailure)failureBlock
 {
-    [self authenticateWithPermissions:nil silent:YES withSuccess:successBlock andFailure:failureBlock];
+    [self authenticateWithPermissions:nil silent:YES fromViewController:presentingViewController withSuccess:successBlock andFailure:failureBlock ];
 }
 
-- (void)authenticateWithPermissions:(NSArray *)permissions withSuccess:(PDKClientSuccess)successBlock andFailure:(PDKClientFailure)failureBlock
+- (void)authenticateWithPermissions:(NSArray *)permissions fromViewController:(UIViewController *)presentingViewController withSuccess:(PDKClientSuccess)successBlock andFailure:(PDKClientFailure)failureBlock
 {
-    [self authenticateWithPermissions:permissions silent:NO withSuccess:successBlock andFailure:failureBlock];
+    [self authenticateWithPermissions:permissions silent:NO fromViewController:presentingViewController withSuccess:successBlock andFailure:failureBlock];
 }
 
 - (void)authenticateWithPermissions:(NSArray *)permissions
                              silent:(BOOL)silent
+                 fromViewController:(UIViewController *)presentingViewController
                         withSuccess:(PDKClientSuccess)successBlock
                          andFailure:(PDKClientFailure)failureBlock
 {
@@ -162,7 +165,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
         PDKClientFailure localFailureBlock = ^(NSError *error) {
             if (permissions != nil) {
                 [SSKeychain deletePasswordForService:PDKPinterestSDK account:PDKPinterestSDKUsername];
-                [weakSelf authenticateWithPermissions:permissions withSuccess:successBlock andFailure:failureBlock];
+                [weakSelf authenticateWithPermissions:permissions fromViewController:presentingViewController withSuccess:successBlock andFailure:failureBlock];
             } else if (failureBlock) {
                 failureBlock(error);
             }
@@ -206,7 +209,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
         NSURL *oauthURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestAppOAuthURLString, [params _PDK_queryStringValue]]];
         
         if ([[UIApplication sharedApplication] canOpenURL:oauthURL]) {
-            [PDKClient openURL:oauthURL];
+            [PDKClient openURL:oauthURL fromViewController:presentingViewController];
         } else {
             NSString *redirectURL = [NSString stringWithFormat:@"pdk%@://", self.appId];
             params = @{@"client_id" : self.appId,
@@ -217,7 +220,7 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
             
             // open the web oauth
             oauthURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestWebOAuthURLString, [params _PDK_queryStringValue]]];
-            [PDKClient openURL:oauthURL];
+            [PDKClient openURL:oauthURL fromViewController:presentingViewController];
         }
     } else if (silent && failureBlock) {
         // silent was yes, but we did not have a cached token. that counts as a failure.
@@ -237,11 +240,8 @@ static NSString * const kPDKPinterestWebOAuthURLString = @"https://api.pinterest
     NSString *urlScheme = [url scheme];
     if ([urlScheme isEqualToString:self.clientRedirectURLString]) {
         // if we came here via SFSafariViewController then we need to dismiss the VC
-        if (NSClassFromString(@"SFSafariViewController") != nil) {
-            UIViewController *mainViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-            if ([[mainViewController presentedViewController] isKindOfClass:[SFSafariViewController class]]) {
-                [mainViewController dismissViewControllerAnimated:YES completion:nil];
-            }
+        if (self.safariViewController != nil) {
+            [self.safariViewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         }
         
         // get the oauth token
@@ -589,13 +589,15 @@ static void defaultFailureAction(PDKClientFailure failureBlock, NSError *error)
     [self postPath:@"pins/" parameters:parameters withSuccess:successBlock andFailure:failureBlock];
 }
 
-+ (void)openURL:(NSURL *)url
++ (void)openURL:(NSURL *)url fromViewController:(UIViewController *)presentingViewController
 {
     NSString *scheme = [[url scheme] lowercaseString];
     if (NSClassFromString(@"SFSafariViewController") != nil && ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"])) {
-        UIViewController *viewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-        SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
-        [viewController presentViewController:safariViewController animated:YES completion:nil];
+        [PDKClient sharedInstance].safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+        if (!presentingViewController) {
+            presentingViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+        }
+        [presentingViewController presentViewController:[PDKClient sharedInstance].safariViewController animated:YES completion:nil];
     } else if ([[UIApplication sharedApplication] canOpenURL:url]) {
         [[UIApplication sharedApplication] openURL:url];
     }

--- a/Pod/Classes/PDKPin.h
+++ b/Pod/Classes/PDKPin.h
@@ -98,6 +98,7 @@ typedef void (^PDKUnauthPinCreationFailure)(NSError *error);
  *  @param sourceURL          The URL to the source of the pin
  *  @param suggestedBoardName A suggested name of a board to pin to
  *  @param pinDescription     The description of the pin
+ *  @param presentingViewController The ViewController the SafariViewController (if available) will present from if the Pinterest app is not installed. If nil, an attempt will be made to automatically determine the proper presenting view controller.
  *  @param successBlock Called when the API call succeeds
  *  @param failureBlock Called when the API call fails
  */
@@ -105,6 +106,7 @@ typedef void (^PDKUnauthPinCreationFailure)(NSError *error);
                    link:(NSURL *)sourceURL
      suggestedBoardName:(NSString *)suggestedBoardName
                    note:(NSString *)pinDescription
+     fromViewController:(UIViewController *)presentingViewController
             withSuccess:(PDKUnauthPinCreationSuccess)pinSuccessBlock
              andFailure:(PDKUnauthPinCreationFailure)pinFailureBlock;
 

--- a/Pod/Classes/PDKPin.m
+++ b/Pod/Classes/PDKPin.m
@@ -89,6 +89,7 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
                    link:(NSURL *)sourceURL
      suggestedBoardName:(NSString *)suggestedBoardName
                    note:(NSString *)pinDescription
+     fromViewController:(UIViewController *)presentingViewController
             withSuccess:(PDKUnauthPinCreationSuccess)pinSuccessBlock
              andFailure:(PDKUnauthPinCreationFailure)pinFailureBlock
 {
@@ -110,14 +111,14 @@ static NSString * const kPDKPinterestWebPinItURLString = @"http://www.pinterest.
     // check to see if the Pinterest app is installed
     NSURL *pinitURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestAppPinItURLString, [params _PDK_queryStringValue]]];
     if ([[UIApplication sharedApplication] canOpenURL:pinitURL]) {
-        [PDKClient openURL:pinitURL];
+        [PDKClient openURL:pinitURL fromViewController:presentingViewController];
     } else {
         // These params do not need to be double-encoded because Safari is going to handle it.
         NSDictionary *webParams = @{@"url": [sourceURL absoluteString],
                                     @"media": [imageURL absoluteString],
                                     @"description": pinDescription};
         NSURL *pinitWebURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", kPDKPinterestWebPinItURLString, [webParams _PDK_queryStringValue]]];
-        [PDKClient openURL:pinitWebURL];
+        [PDKClient openURL:pinitWebURL fromViewController:presentingViewController];
     }
 }
 


### PR DESCRIPTION
Great work on this SDK -- super helpful and easy to use!

This resolves issue https://github.com/pinterest/ios-pdk/issues/93.

By passing in the presenting view controller, we can guarantee the SafariViewController will be displayed.
By storing the SafariViewController in the PDKClient Singleton, we can dismiss it properly, as well.

The code used to find the topmost view controller for presenting the SafariViewController before did not work in all instances. That code will still be used if the presentingViewController passed in is nil.

Thank you!